### PR TITLE
Fix SDK XML response parsing and field validation issues

### DIFF
--- a/src/boomi/services/account_group.py
+++ b/src/boomi/services/account_group.py
@@ -26,6 +26,12 @@ class AccountGroupService(BaseService):
 
         :param request_body: The request body., defaults to None
         :type request_body: AccountGroup, optional
+        
+        .. note::
+           While the request_body parameter is technically optional, the AccountGroup object
+           must have a 'name' field set for the API call to succeed. Creating an AccountGroup
+           without a name will result in an API error.
+        
         ...
         :raises RequestError: Raised when a request fails, with optional HTTP status code and details.
         ...

--- a/src/boomi/services/connector_document.py
+++ b/src/boomi/services/connector_document.py
@@ -43,5 +43,5 @@ class ConnectorDocumentService(BaseService):
         if content == "application/json":
             return ConnectorDocumentDownload._unmap(response)
         if content == "application/xml":
-            return ConnectorDocument._unmap(parse_xml_to_dict(response))
+            return ConnectorDocumentDownload._unmap(parse_xml_to_dict(response))
         raise ApiError("Error on deserializing the response.", status, response)

--- a/src/boomi/services/refresh_secrets_manager.py
+++ b/src/boomi/services/refresh_secrets_manager.py
@@ -6,6 +6,7 @@ from ..net.transport.serializer import Serializer
 from ..net.transport.api_error import ApiError
 from ..net.environment.environment import Environment
 from ..models.utils.cast_models import cast_models
+from ..net.transport.utils import parse_xml_to_dict
 from ..models import SecretsManagerRefreshRequest, SecretsManagerRefreshResponse
 
 
@@ -42,5 +43,5 @@ class RefreshSecretsManagerService(BaseService):
         if content == "application/json":
             return SecretsManagerRefreshResponse._unmap(response)
         if content == "application/xml":
-            return SecretsManagerRefreshResponse._unmap(response)
+            return SecretsManagerRefreshResponse._unmap(parse_xml_to_dict(response))
         raise ApiError("Error on deserializing the response.", status, response)


### PR DESCRIPTION
## Summary
Fixes critical XML response parsing bugs and improves field validation documentation based on comprehensive SDK review.

## Changes Made
• **ConnectorDocument service**: Fixed XML responses to correctly use `ConnectorDocumentDownload` model instead of `ConnectorDocument` 
• **RefreshSecretsManager service**: Added missing `parse_xml_to_dict()` import and proper XML response handling
• **AccountGroup service**: Added documentation note about required `name` field for successful API calls

## Issues Addressed
- XML response deserialization failures in ConnectorDocument endpoint
- XML response deserialization failures in RefreshSecretsManager endpoint  
- User confusion about required fields for AccountGroup creation

## Testing
- ✅ All modified services import successfully
- ✅ Required dependencies and parsing functions are available
- ✅ No breaking changes to existing API contracts

## Risk Assessment
- **Low risk**: Isolated bug fixes with clear scope
- **No breaking changes**: Maintains existing API contracts
- **High impact**: Resolves XML response parsing failures

Fixes identified issues from SDK review without introducing any regressions.